### PR TITLE
Chore: Allow different http connections

### DIFF
--- a/EventSource/Event.swift
+++ b/EventSource/Event.swift
@@ -10,59 +10,59 @@ import Foundation
 
 enum Event {
 	case event(id: String?, event: String?, data: String?, time: String?)
-	
+
 	init?(eventString: String?, newLineCharacters: [String]) {
 		guard let eventString = eventString else { return nil }
-		
+
 		if eventString.hasPrefix(":") {
 			return nil
 		}
-		
+
 		self = Event.parseEvent(eventString, newLineCharacters: newLineCharacters)
 	}
-	
+
 	var id: String? {
 		guard case let .event(eventId, _, _, _) = self else { return nil }
 		return eventId
 	}
-	
+
 	var event: String? {
 		guard case let .event(_, eventName, _, _) = self else { return nil }
 		return eventName
 	}
-	
+
 	var data: String? {
 		guard case let .event(_, _, eventData, _) = self else { return nil }
 		return eventData
 	}
-	
+
 	var retryTime: Int? {
 		guard case let .event(_, _, _, aTime) = self, let time = aTime else { return nil }
 		return Int(time.trimmingCharacters(in: CharacterSet.whitespaces))
 	}
-	
+
 	var onlyRetryEvent: Bool? {
 		guard case let .event(id, name, data, time) = self else { return nil }
 		let otherThanTime = id ?? name ?? data
-		
+
 		if otherThanTime == nil && time != nil {
 			return true
 		}
-		
+
 		return false
-		
+
 	}
 }
 
 private extension Event {
-	
+
 	static func parseEvent(_ eventString: String, newLineCharacters: [String]) -> Event {
 		var event: [String: String?] = [:]
-		
+
 		for line in eventString.components(separatedBy: CharacterSet.newlines) as [String] {
 			let (akey, value) = Event.parseLine(line, newLineCharacters: newLineCharacters)
 			guard let key = akey else { continue }
-			
+
 			if let value = value, let previousValue = event[key] ?? nil {
 				event[key] = "\(previousValue)\n\(value)"
 			} else if let value = value {
@@ -71,7 +71,7 @@ private extension Event {
 				event[key] = nil
 			}
 		}
-		
+
 		// the only possible field names for events are: id, event and data. Everything else is ignored.
 		return .event(
 			id: event["id"] ?? nil,
@@ -80,24 +80,24 @@ private extension Event {
 			time: event["retry"] ?? nil
 		)
 	}
-	
+
 	static func parseLine(_ line: String, newLineCharacters: [String]) -> (key: String?, value: String?) {
 		var key: NSString?, value: NSString?
 		let scanner = Scanner(string: line)
 		scanner.scanUpTo(":", into: &key)
 		scanner.scanString(":", into: nil)
-		
+
 		for newline in newLineCharacters {
 			if scanner.scanUpTo(newline, into: &value) {
 				break
 			}
 		}
-		
+
 		// for id and data if they come empty they should return an empty string value.
 		if key != "event" && value == nil {
 			value = ""
 		}
-		
+
 		return (key as String?, value as String?)
 	}
 }

--- a/EventSource/Event.swift
+++ b/EventSource/Event.swift
@@ -9,95 +9,95 @@
 import Foundation
 
 enum Event {
-    case event(id: String?, event: String?, data: String?, time: String?)
-
-    init?(eventString: String?, newLineCharacters: [String]) {
-        guard let eventString = eventString else { return nil }
-
-        if eventString.hasPrefix(":") {
-            return nil
-        }
-
-        self = Event.parseEvent(eventString, newLineCharacters: newLineCharacters)
-    }
-
-    var id: String? {
-        guard case let .event(eventId, _, _, _) = self else { return nil }
-        return eventId
-    }
-
-    var event: String? {
-        guard case let .event(_, eventName, _, _) = self else { return nil }
-        return eventName
-    }
-
-    var data: String? {
-        guard case let .event(_, _, eventData, _) = self else { return nil }
-        return eventData
-    }
-
-    var retryTime: Int? {
-        guard case let .event(_, _, _, aTime) = self, let time = aTime else { return nil }
-        return Int(time.trimmingCharacters(in: CharacterSet.whitespaces))
-    }
-
-    var onlyRetryEvent: Bool? {
-        guard case let .event(id, name, data, time) = self else { return nil }
-        let otherThanTime = id ?? name ?? data
-
-        if otherThanTime == nil && time != nil {
-            return true
-        }
-
-        return false
-
-    }
+	case event(id: String?, event: String?, data: String?, time: String?)
+	
+	init?(eventString: String?, newLineCharacters: [String]) {
+		guard let eventString = eventString else { return nil }
+		
+		if eventString.hasPrefix(":") {
+			return nil
+		}
+		
+		self = Event.parseEvent(eventString, newLineCharacters: newLineCharacters)
+	}
+	
+	var id: String? {
+		guard case let .event(eventId, _, _, _) = self else { return nil }
+		return eventId
+	}
+	
+	var event: String? {
+		guard case let .event(_, eventName, _, _) = self else { return nil }
+		return eventName
+	}
+	
+	var data: String? {
+		guard case let .event(_, _, eventData, _) = self else { return nil }
+		return eventData
+	}
+	
+	var retryTime: Int? {
+		guard case let .event(_, _, _, aTime) = self, let time = aTime else { return nil }
+		return Int(time.trimmingCharacters(in: CharacterSet.whitespaces))
+	}
+	
+	var onlyRetryEvent: Bool? {
+		guard case let .event(id, name, data, time) = self else { return nil }
+		let otherThanTime = id ?? name ?? data
+		
+		if otherThanTime == nil && time != nil {
+			return true
+		}
+		
+		return false
+		
+	}
 }
 
 private extension Event {
-
-    static func parseEvent(_ eventString: String, newLineCharacters: [String]) -> Event {
-        var event: [String: String?] = [:]
-
-        for line in eventString.components(separatedBy: CharacterSet.newlines) as [String] {
-            let (akey, value) = Event.parseLine(line, newLineCharacters: newLineCharacters)
-            guard let key = akey else { continue }
-
-            if let value = value, let previousValue = event[key] ?? nil {
-                event[key] = "\(previousValue)\n\(value)"
-            } else if let value = value {
-                event[key] = value
-            } else {
-                event[key] = nil
-            }
-        }
-
-        // the only possible field names for events are: id, event and data. Everything else is ignored.
-        return .event(
-            id: event["id"] ?? nil,
-            event: event["event"] ?? nil,
-            data: event["data"] ?? nil,
-            time: event["retry"] ?? nil
-        )
-    }
-
-    static func parseLine(_ line: String, newLineCharacters: [String]) -> (key: String?, value: String?) {
-        var key: NSString?, value: NSString?
-        let scanner = Scanner(string: line)
-        scanner.scanUpTo(":", into: &key)
-        scanner.scanString(":", into: nil)
-
-        for newline in newLineCharacters {
-            if scanner.scanUpTo(newline, into: &value) {
-                break
-            }
-        }
-
-        // for id and data if they come empty they should return an empty string value.
-        if key != "event" && value == nil {
-            value = ""
-        }
-
-        return (key as String?, value as String?)
-    }
+	
+	static func parseEvent(_ eventString: String, newLineCharacters: [String]) -> Event {
+		var event: [String: String?] = [:]
+		
+		for line in eventString.components(separatedBy: CharacterSet.newlines) as [String] {
+			let (akey, value) = Event.parseLine(line, newLineCharacters: newLineCharacters)
+			guard let key = akey else { continue }
+			
+			if let value = value, let previousValue = event[key] ?? nil {
+				event[key] = "\(previousValue)\n\(value)"
+			} else if let value = value {
+				event[key] = value
+			} else {
+				event[key] = nil
+			}
+		}
+		
+		// the only possible field names for events are: id, event and data. Everything else is ignored.
+		return .event(
+			id: event["id"] ?? nil,
+			event: event["event"] ?? nil,
+			data: event["data"] ?? nil,
+			time: event["retry"] ?? nil
+		)
+	}
+	
+	static func parseLine(_ line: String, newLineCharacters: [String]) -> (key: String?, value: String?) {
+		var key: NSString?, value: NSString?
+		let scanner = Scanner(string: line)
+		scanner.scanUpTo(":", into: &key)
+		scanner.scanString(":", into: nil)
+		
+		for newline in newLineCharacters {
+			if scanner.scanUpTo(newline, into: &value) {
+				break
+			}
+		}
+		
+		// for id and data if they come empty they should return an empty string value.
+		if key != "event" && value == nil {
+			value = ""
+		}
+		
+		return (key as String?, value as String?)
+	}
 }

--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -9,24 +9,24 @@
 import Foundation
 
 public enum EventSourceState {
-    case connecting
-    case open
-    case closed
+	case connecting
+	case open
+	case closed
 }
 
 public protocol EventSourceProtocol {
-    var headers: [String: String] { get }
-
-    /// RetryTime: This can be changed remotly if the server sends an event `retry:`
-    var retryTime: Int { get }
-
-    /// The last event id received from server. This id is neccesary to keep track of the last event-id received to avoid
-    /// receiving duplicate events after a reconnection.
-    var lastEventId: String? { get }
-
-    /// Current state of EventSource
-    var readyState: EventSourceState { get }
-
+	var headers: [String: String] { get }
+	
+	/// RetryTime: This can be changed remotly if the server sends an event `retry:`
+	var retryTime: Int { get }
+	
+	/// The last event id received from server. This id is neccesary to keep track of the last event-id received to avoid
+	/// receiving duplicate events after a reconnection.
+	var lastEventId: String? { get }
+	
+	/// Current state of EventSource
+	var readyState: EventSourceState { get }
+	
 	/// Method used to connect to server.
 	///
 	/// It can receive an optional lastEventId indicating the Last-Event-ID.
@@ -37,225 +37,225 @@ public protocol EventSourceProtocol {
 	/// - Parameter httpBody: http body to use for this connection.
 	/// - Parameter lastEventId: optional value that is going to be added on the request header to server.
 	func connect(url: URL, headers: [String: String], httpMethod: String, httpBody: Data?, lastEventId: String?)
-
-    /// Method used to disconnect from server.
-    func disconnect()
-
-    /// Returns the list of event names that we are currently listening for.
-    ///
-    /// - Returns: List of event names.
-    func events() -> [String]
-
-    /// Callback called when EventSource has successfully connected to the server.
-    ///
-    /// - Parameter onOpenCallback: callback
-    func onOpen(_ onOpenCallback: @escaping (() -> Void))
-
-    /// Callback called once EventSource has disconnected from server. This can happen for multiple reasons.
-    /// The server could have requested the disconnection or maybe a network layer error, wrong URL or any other
-    /// error. The callback receives as parameters the status code of the disconnection, if we should reconnect or not
-    /// following event source rules and finally the network layer error if any. All this information is more than
-    /// enought for you to take a decition if you should reconnect or not.
-    /// - Parameter onOpenCallback: callback
-    func onComplete(_ onComplete: @escaping ((Int?, Bool?, NSError?) -> Void))
-
-    /// This callback is called everytime an event with name "message" or no name is received.
-    func onMessage(_ onMessageCallback: @escaping ((_ id: String?, _ event: String?, _ data: String?) -> Void))
-
-    /// Add an event handler for an specific event name.
-    ///
-    /// - Parameters:
-    ///   - event: name of the event to receive
-    ///   - handler: this handler will be called everytime an event is received with this event-name
-    func addEventListener(_ event: String,
-                          handler: @escaping ((_ id: String?, _ event: String?, _ data: String?) -> Void))
-
-    /// Remove an event handler for the event-name
-    ///
-    /// - Parameter event: name of the listener to be remove from event source.
-    func removeEventListener(_ event: String)
+	
+	/// Method used to disconnect from server.
+	func disconnect()
+	
+	/// Returns the list of event names that we are currently listening for.
+	///
+	/// - Returns: List of event names.
+	func events() -> [String]
+	
+	/// Callback called when EventSource has successfully connected to the server.
+	///
+	/// - Parameter onOpenCallback: callback
+	func onOpen(_ onOpenCallback: @escaping (() -> Void))
+	
+	/// Callback called once EventSource has disconnected from server. This can happen for multiple reasons.
+	/// The server could have requested the disconnection or maybe a network layer error, wrong URL or any other
+	/// error. The callback receives as parameters the status code of the disconnection, if we should reconnect or not
+	/// following event source rules and finally the network layer error if any. All this information is more than
+	/// enought for you to take a decition if you should reconnect or not.
+	/// - Parameter onOpenCallback: callback
+	func onComplete(_ onComplete: @escaping ((Int?, Bool?, NSError?) -> Void))
+	
+	/// This callback is called everytime an event with name "message" or no name is received.
+	func onMessage(_ onMessageCallback: @escaping ((_ id: String?, _ event: String?, _ data: String?) -> Void))
+	
+	/// Add an event handler for an specific event name.
+	///
+	/// - Parameters:
+	///   - event: name of the event to receive
+	///   - handler: this handler will be called everytime an event is received with this event-name
+	func addEventListener(_ event: String,
+						  handler: @escaping ((_ id: String?, _ event: String?, _ data: String?) -> Void))
+	
+	/// Remove an event handler for the event-name
+	///
+	/// - Parameter event: name of the listener to be remove from event source.
+	func removeEventListener(_ event: String)
 }
 
 open class EventSource: NSObject, EventSourceProtocol, URLSessionDataDelegate {
-    static let DefaultRetryTime = 3000
-
-    private(set) public var lastEventId: String?
-    private(set) public var retryTime = EventSource.DefaultRetryTime
-    private(set) public var headers: [String: String]
-    private(set) public var readyState: EventSourceState
-
-    private var onOpenCallback: (() -> Void)?
-    private var onComplete: ((Int?, Bool?, NSError?) -> Void)?
-    private var onMessageCallback: ((_ id: String?, _ event: String?, _ data: String?) -> Void)?
-    private var eventListeners: [String: (_ id: String?, _ event: String?, _ data: String?) -> Void] = [:]
-
-    private var eventStreamParser: EventStreamParser?
-    private var operationQueue: OperationQueue
-    private var mainQueue = DispatchQueue.main
-    private var urlSession: URLSession?
-
+	static let DefaultRetryTime = 3000
+	
+	private(set) public var lastEventId: String?
+	private(set) public var retryTime = EventSource.DefaultRetryTime
+	private(set) public var headers: [String: String]
+	private(set) public var readyState: EventSourceState
+	
+	private var onOpenCallback: (() -> Void)?
+	private var onComplete: ((Int?, Bool?, NSError?) -> Void)?
+	private var onMessageCallback: ((_ id: String?, _ event: String?, _ data: String?) -> Void)?
+	private var eventListeners: [String: (_ id: String?, _ event: String?, _ data: String?) -> Void] = [:]
+	
+	private var eventStreamParser: EventStreamParser?
+	private var operationQueue: OperationQueue
+	private var mainQueue = DispatchQueue.main
+	private var urlSession: URLSession?
+	
 	public override init() {
 		headers = [:]
-        readyState = EventSourceState.closed
-        operationQueue = OperationQueue()
-        operationQueue.maxConcurrentOperationCount = 1
-
-        super.init()
-    }
-
+		readyState = EventSourceState.closed
+		operationQueue = OperationQueue()
+		operationQueue.maxConcurrentOperationCount = 1
+		
+		super.init()
+	}
+	
 	public func connect(
-	 url: URL,
-	 headers: [String: String] = [:],
-	 httpMethod: String = "GET",
-	 httpBody: Data? = nil,
-	 lastEventId: String? = nil
- ) {
-	 self.headers = headers
-	 eventStreamParser = EventStreamParser()
-	 readyState = .connecting
-
-	 let configuration = sessionConfiguration(lastEventId: lastEventId)
-	 urlSession = URLSession(configuration: configuration, delegate: self, delegateQueue: operationQueue)
-	 var request = URLRequest(url: url)
-	 request.httpMethod = httpMethod
-	 request.httpBody = httpBody
-	 urlSession?.dataTask(with: request).resume()
- }
-
-    public func disconnect() {
-        readyState = .closed
-        urlSession?.invalidateAndCancel()
-    }
-
-    public func onOpen(_ onOpenCallback: @escaping (() -> Void)) {
-        self.onOpenCallback = onOpenCallback
-    }
-
-    public func onComplete(_ onComplete: @escaping ((Int?, Bool?, NSError?) -> Void)) {
-        self.onComplete = onComplete
-    }
-
-    public func onMessage(_ onMessageCallback: @escaping ((_ id: String?, _ event: String?, _ data: String?) -> Void)) {
-        self.onMessageCallback = onMessageCallback
-    }
-
-    public func addEventListener(_ event: String,
-                                 handler: @escaping ((_ id: String?, _ event: String?, _ data: String?) -> Void)) {
-        eventListeners[event] = handler
-    }
-
+		url: URL,
+		headers: [String: String] = [:],
+		httpMethod: String = "GET",
+		httpBody: Data? = nil,
+		lastEventId: String? = nil
+	) {
+		self.headers = headers
+		eventStreamParser = EventStreamParser()
+		readyState = .connecting
+		
+		let configuration = sessionConfiguration(lastEventId: lastEventId)
+		urlSession = URLSession(configuration: configuration, delegate: self, delegateQueue: operationQueue)
+		var request = URLRequest(url: url)
+		request.httpMethod = httpMethod
+		request.httpBody = httpBody
+		urlSession?.dataTask(with: request).resume()
+	}
+	
+	public func disconnect() {
+		readyState = .closed
+		urlSession?.invalidateAndCancel()
+	}
+	
+	public func onOpen(_ onOpenCallback: @escaping (() -> Void)) {
+		self.onOpenCallback = onOpenCallback
+	}
+	
+	public func onComplete(_ onComplete: @escaping ((Int?, Bool?, NSError?) -> Void)) {
+		self.onComplete = onComplete
+	}
+	
+	public func onMessage(_ onMessageCallback: @escaping ((_ id: String?, _ event: String?, _ data: String?) -> Void)) {
+		self.onMessageCallback = onMessageCallback
+	}
+	
+	public func addEventListener(_ event: String,
+								 handler: @escaping ((_ id: String?, _ event: String?, _ data: String?) -> Void)) {
+		eventListeners[event] = handler
+	}
+	
 	public func removeEventListener(_ event: String) {
 		eventListeners.removeValue(forKey: event)
 	}
-
+	
 	public func events() -> [String] {
 		return Array(eventListeners.keys)
 	}
-
-    open func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-
+	
+	open func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+		
 		if readyState != .open {
-            return
-        }
-
-        if let events = eventStreamParser?.append(data: data) {
-            notifyReceivedEvents(events)
-        }
-    }
-
-    open func urlSession(_ session: URLSession,
-                         dataTask: URLSessionDataTask,
-                         didReceive response: URLResponse,
-                         completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
-
-        completionHandler(URLSession.ResponseDisposition.allow)
-
-        readyState = .open
-        mainQueue.async { [weak self] in self?.onOpenCallback?() }
-    }
-
-    open func urlSession(_ session: URLSession,
-                         task: URLSessionTask,
-                         didCompleteWithError error: Error?) {
-
-        guard let responseStatusCode = (task.response as? HTTPURLResponse)?.statusCode else {
-            mainQueue.async { [weak self] in self?.onComplete?(nil, nil, error as NSError?) }
-            return
-        }
-
-        let reconnect = shouldReconnect(statusCode: responseStatusCode)
-        mainQueue.async { [weak self] in self?.onComplete?(responseStatusCode, reconnect, nil) }
-    }
-
-    open func urlSession(_ session: URLSession,
-                         task: URLSessionTask,
-                         willPerformHTTPRedirection response: HTTPURLResponse,
-                         newRequest request: URLRequest,
-                         completionHandler: @escaping (URLRequest?) -> Void) {
-
-        var newRequest = request
-        self.headers.forEach { newRequest.setValue($1, forHTTPHeaderField: $0) }
-        completionHandler(newRequest)
-    }
+			return
+		}
+		
+		if let events = eventStreamParser?.append(data: data) {
+			notifyReceivedEvents(events)
+		}
+	}
+	
+	open func urlSession(_ session: URLSession,
+						 dataTask: URLSessionDataTask,
+						 didReceive response: URLResponse,
+						 completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+		
+		completionHandler(URLSession.ResponseDisposition.allow)
+		
+		readyState = .open
+		mainQueue.async { [weak self] in self?.onOpenCallback?() }
+	}
+	
+	open func urlSession(_ session: URLSession,
+						 task: URLSessionTask,
+						 didCompleteWithError error: Error?) {
+		
+		guard let responseStatusCode = (task.response as? HTTPURLResponse)?.statusCode else {
+			mainQueue.async { [weak self] in self?.onComplete?(nil, nil, error as NSError?) }
+			return
+		}
+		
+		let reconnect = shouldReconnect(statusCode: responseStatusCode)
+		mainQueue.async { [weak self] in self?.onComplete?(responseStatusCode, reconnect, nil) }
+	}
+	
+	open func urlSession(_ session: URLSession,
+						 task: URLSessionTask,
+						 willPerformHTTPRedirection response: HTTPURLResponse,
+						 newRequest request: URLRequest,
+						 completionHandler: @escaping (URLRequest?) -> Void) {
+		
+		var newRequest = request
+		self.headers.forEach { newRequest.setValue($1, forHTTPHeaderField: $0) }
+		completionHandler(newRequest)
+	}
 }
 
 internal extension EventSource {
-
-    func sessionConfiguration(lastEventId: String?) -> URLSessionConfiguration {
-
-        var additionalHeaders = headers
-        if let eventID = lastEventId {
-            additionalHeaders["Last-Event-Id"] = eventID
-        }
-
-        additionalHeaders["Accept"] = "text/event-stream"
-        additionalHeaders["Cache-Control"] = "no-cache"
-
-        let sessionConfiguration = URLSessionConfiguration.default
-        sessionConfiguration.timeoutIntervalForRequest = TimeInterval(INT_MAX)
-        sessionConfiguration.timeoutIntervalForResource = TimeInterval(INT_MAX)
-        sessionConfiguration.httpAdditionalHeaders = additionalHeaders
-
-        return sessionConfiguration
-    }
-
-    func readyStateOpen() {
-        readyState = .open
-    }
+	
+	func sessionConfiguration(lastEventId: String?) -> URLSessionConfiguration {
+		
+		var additionalHeaders = headers
+		if let eventID = lastEventId {
+			additionalHeaders["Last-Event-Id"] = eventID
+		}
+		
+		additionalHeaders["Accept"] = "text/event-stream"
+		additionalHeaders["Cache-Control"] = "no-cache"
+		
+		let sessionConfiguration = URLSessionConfiguration.default
+		sessionConfiguration.timeoutIntervalForRequest = TimeInterval(INT_MAX)
+		sessionConfiguration.timeoutIntervalForResource = TimeInterval(INT_MAX)
+		sessionConfiguration.httpAdditionalHeaders = additionalHeaders
+		
+		return sessionConfiguration
+	}
+	
+	func readyStateOpen() {
+		readyState = .open
+	}
 }
 
 private extension EventSource {
-
-    func notifyReceivedEvents(_ events: [Event]) {
-
-        for event in events {
-            lastEventId = event.id
-            retryTime = event.retryTime ?? EventSource.DefaultRetryTime
-
-            if event.onlyRetryEvent == true {
-                continue
-            }
-
-            if event.event == nil || event.event == "message" {
-                mainQueue.async { [weak self] in self?.onMessageCallback?(event.id, "message", event.data) }
-            }
-
-            if let eventName = event.event, let eventHandler = eventListeners[eventName] {
-                mainQueue.async { eventHandler(event.id, event.event, event.data) }
-            }
-        }
-    }
-
-    // Following "5 Processing model" from:
-    // https://www.w3.org/TR/2009/WD-eventsource-20090421/#handler-eventsource-onerror
-    func shouldReconnect(statusCode: Int) -> Bool {
-        switch statusCode {
-        case 200:
-            return false
-        case _ where statusCode > 200 && statusCode < 300:
-            return true
-        default:
-            return false
-        }
-    }
+	
+	func notifyReceivedEvents(_ events: [Event]) {
+		
+		for event in events {
+			lastEventId = event.id
+			retryTime = event.retryTime ?? EventSource.DefaultRetryTime
+			
+			if event.onlyRetryEvent == true {
+				continue
+			}
+			
+			if event.event == nil || event.event == "message" {
+				mainQueue.async { [weak self] in self?.onMessageCallback?(event.id, "message", event.data) }
+			}
+			
+			if let eventName = event.event, let eventHandler = eventListeners[eventName] {
+				mainQueue.async { eventHandler(event.id, event.event, event.data) }
+			}
+		}
+	}
+	
+	// Following "5 Processing model" from:
+	// https://www.w3.org/TR/2009/WD-eventsource-20090421/#handler-eventsource-onerror
+	func shouldReconnect(statusCode: Int) -> Bool {
+		switch statusCode {
+		case 200:
+			return false
+		case _ where statusCode > 200 && statusCode < 300:
+			return true
+		default:
+			return false
+		}
+	}
 }

--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -20,7 +20,7 @@ public protocol EventSourceProtocol {
 	/// RetryTime: This can be changed remotly if the server sends an event `retry:`
 	var retryTime: Int { get }
 
-	/// The last event id received from server. This id is neccesary to keep track of the last event-id received to avoid
+	/// The last event id received from server. This id is necessary to keep track of the last event-id received to avoid
 	/// receiving duplicate events after a reconnection.
 	var lastEventId: String? { get }
 

--- a/EventSource/EventSource.swift
+++ b/EventSource/EventSource.swift
@@ -16,17 +16,17 @@ public enum EventSourceState {
 
 public protocol EventSourceProtocol {
 	var headers: [String: String] { get }
-	
+
 	/// RetryTime: This can be changed remotly if the server sends an event `retry:`
 	var retryTime: Int { get }
-	
+
 	/// The last event id received from server. This id is neccesary to keep track of the last event-id received to avoid
 	/// receiving duplicate events after a reconnection.
 	var lastEventId: String? { get }
-	
+
 	/// Current state of EventSource
 	var readyState: EventSourceState { get }
-	
+
 	/// Method used to connect to server.
 	///
 	/// It can receive an optional lastEventId indicating the Last-Event-ID.
@@ -37,20 +37,20 @@ public protocol EventSourceProtocol {
 	/// - Parameter httpBody: http body to use for this connection.
 	/// - Parameter lastEventId: optional value that is going to be added on the request header to server.
 	func connect(url: URL, headers: [String: String], httpMethod: String, httpBody: Data?, lastEventId: String?)
-	
+
 	/// Method used to disconnect from server.
 	func disconnect()
-	
+
 	/// Returns the list of event names that we are currently listening for.
 	///
 	/// - Returns: List of event names.
 	func events() -> [String]
-	
+
 	/// Callback called when EventSource has successfully connected to the server.
 	///
 	/// - Parameter onOpenCallback: callback
 	func onOpen(_ onOpenCallback: @escaping (() -> Void))
-	
+
 	/// Callback called once EventSource has disconnected from server. This can happen for multiple reasons.
 	/// The server could have requested the disconnection or maybe a network layer error, wrong URL or any other
 	/// error. The callback receives as parameters the status code of the disconnection, if we should reconnect or not
@@ -58,10 +58,10 @@ public protocol EventSourceProtocol {
 	/// enought for you to take a decition if you should reconnect or not.
 	/// - Parameter onOpenCallback: callback
 	func onComplete(_ onComplete: @escaping ((Int?, Bool?, NSError?) -> Void))
-	
+
 	/// This callback is called everytime an event with name "message" or no name is received.
 	func onMessage(_ onMessageCallback: @escaping ((_ id: String?, _ event: String?, _ data: String?) -> Void))
-	
+
 	/// Add an event handler for an specific event name.
 	///
 	/// - Parameters:
@@ -69,7 +69,7 @@ public protocol EventSourceProtocol {
 	///   - handler: this handler will be called everytime an event is received with this event-name
 	func addEventListener(_ event: String,
 						  handler: @escaping ((_ id: String?, _ event: String?, _ data: String?) -> Void))
-	
+
 	/// Remove an event handler for the event-name
 	///
 	/// - Parameter event: name of the listener to be remove from event source.
@@ -78,31 +78,31 @@ public protocol EventSourceProtocol {
 
 open class EventSource: NSObject, EventSourceProtocol, URLSessionDataDelegate {
 	static let DefaultRetryTime = 3000
-	
+
 	private(set) public var lastEventId: String?
 	private(set) public var retryTime = EventSource.DefaultRetryTime
 	private(set) public var headers: [String: String]
 	private(set) public var readyState: EventSourceState
-	
+
 	private var onOpenCallback: (() -> Void)?
 	private var onComplete: ((Int?, Bool?, NSError?) -> Void)?
 	private var onMessageCallback: ((_ id: String?, _ event: String?, _ data: String?) -> Void)?
 	private var eventListeners: [String: (_ id: String?, _ event: String?, _ data: String?) -> Void] = [:]
-	
+
 	private var eventStreamParser: EventStreamParser?
 	private var operationQueue: OperationQueue
 	private var mainQueue = DispatchQueue.main
 	private var urlSession: URLSession?
-	
+
 	public override init() {
 		headers = [:]
 		readyState = EventSourceState.closed
 		operationQueue = OperationQueue()
 		operationQueue.maxConcurrentOperationCount = 1
-		
+
 		super.init()
 	}
-	
+
 	public func connect(
 		url: URL,
 		headers: [String: String] = [:],
@@ -113,7 +113,7 @@ open class EventSource: NSObject, EventSourceProtocol, URLSessionDataDelegate {
 		self.headers = headers
 		eventStreamParser = EventStreamParser()
 		readyState = .connecting
-		
+
 		let configuration = sessionConfiguration(lastEventId: lastEventId)
 		urlSession = URLSession(configuration: configuration, delegate: self, delegateQueue: operationQueue)
 		var request = URLRequest(url: url)
@@ -121,78 +121,78 @@ open class EventSource: NSObject, EventSourceProtocol, URLSessionDataDelegate {
 		request.httpBody = httpBody
 		urlSession?.dataTask(with: request).resume()
 	}
-	
+
 	public func disconnect() {
 		readyState = .closed
 		urlSession?.invalidateAndCancel()
 	}
-	
+
 	public func onOpen(_ onOpenCallback: @escaping (() -> Void)) {
 		self.onOpenCallback = onOpenCallback
 	}
-	
+
 	public func onComplete(_ onComplete: @escaping ((Int?, Bool?, NSError?) -> Void)) {
 		self.onComplete = onComplete
 	}
-	
+
 	public func onMessage(_ onMessageCallback: @escaping ((_ id: String?, _ event: String?, _ data: String?) -> Void)) {
 		self.onMessageCallback = onMessageCallback
 	}
-	
+
 	public func addEventListener(_ event: String,
 								 handler: @escaping ((_ id: String?, _ event: String?, _ data: String?) -> Void)) {
 		eventListeners[event] = handler
 	}
-	
+
 	public func removeEventListener(_ event: String) {
 		eventListeners.removeValue(forKey: event)
 	}
-	
+
 	public func events() -> [String] {
 		return Array(eventListeners.keys)
 	}
-	
+
 	open func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-		
+
 		if readyState != .open {
 			return
 		}
-		
+
 		if let events = eventStreamParser?.append(data: data) {
 			notifyReceivedEvents(events)
 		}
 	}
-	
+
 	open func urlSession(_ session: URLSession,
 						 dataTask: URLSessionDataTask,
 						 didReceive response: URLResponse,
 						 completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
-		
+
 		completionHandler(URLSession.ResponseDisposition.allow)
-		
+
 		readyState = .open
 		mainQueue.async { [weak self] in self?.onOpenCallback?() }
 	}
-	
+
 	open func urlSession(_ session: URLSession,
 						 task: URLSessionTask,
 						 didCompleteWithError error: Error?) {
-		
+
 		guard let responseStatusCode = (task.response as? HTTPURLResponse)?.statusCode else {
 			mainQueue.async { [weak self] in self?.onComplete?(nil, nil, error as NSError?) }
 			return
 		}
-		
+
 		let reconnect = shouldReconnect(statusCode: responseStatusCode)
 		mainQueue.async { [weak self] in self?.onComplete?(responseStatusCode, reconnect, nil) }
 	}
-	
+
 	open func urlSession(_ session: URLSession,
 						 task: URLSessionTask,
 						 willPerformHTTPRedirection response: HTTPURLResponse,
 						 newRequest request: URLRequest,
 						 completionHandler: @escaping (URLRequest?) -> Void) {
-		
+
 		var newRequest = request
 		self.headers.forEach { newRequest.setValue($1, forHTTPHeaderField: $0) }
 		completionHandler(newRequest)
@@ -200,52 +200,52 @@ open class EventSource: NSObject, EventSourceProtocol, URLSessionDataDelegate {
 }
 
 internal extension EventSource {
-	
+
 	func sessionConfiguration(lastEventId: String?) -> URLSessionConfiguration {
-		
+
 		var additionalHeaders = headers
 		if let eventID = lastEventId {
 			additionalHeaders["Last-Event-Id"] = eventID
 		}
-		
+
 		additionalHeaders["Accept"] = "text/event-stream"
 		additionalHeaders["Cache-Control"] = "no-cache"
-		
+
 		let sessionConfiguration = URLSessionConfiguration.default
 		sessionConfiguration.timeoutIntervalForRequest = TimeInterval(INT_MAX)
 		sessionConfiguration.timeoutIntervalForResource = TimeInterval(INT_MAX)
 		sessionConfiguration.httpAdditionalHeaders = additionalHeaders
-		
+
 		return sessionConfiguration
 	}
-	
+
 	func readyStateOpen() {
 		readyState = .open
 	}
 }
 
 private extension EventSource {
-	
+
 	func notifyReceivedEvents(_ events: [Event]) {
-		
+
 		for event in events {
 			lastEventId = event.id
 			retryTime = event.retryTime ?? EventSource.DefaultRetryTime
-			
+
 			if event.onlyRetryEvent == true {
 				continue
 			}
-			
+
 			if event.event == nil || event.event == "message" {
 				mainQueue.async { [weak self] in self?.onMessageCallback?(event.id, "message", event.data) }
 			}
-			
+
 			if let eventName = event.event, let eventHandler = eventListeners[eventName] {
 				mainQueue.async { eventHandler(event.id, event.event, event.data) }
 			}
 		}
 	}
-	
+
 	// Following "5 Processing model" from:
 	// https://www.w3.org/TR/2009/WD-eventsource-20090421/#handler-eventsource-onerror
 	func shouldReconnect(statusCode: Int) -> Bool {

--- a/EventSource/EventStreamParser.swift
+++ b/EventSource/EventStreamParser.swift
@@ -9,79 +9,79 @@
 import Foundation
 
 final class EventStreamParser {
-	
+
 	//  Events are separated by end of line. End of line can be:
 	//  \r = CR (Carriage Return) → Used as a new line character in Mac OS before X
 	//  \n = LF (Line Feed) → Used as a new line character in Unix/Mac OS X
 	//  \r\n = CR + LF → Used as a new line character in Windows
 	private let validNewlineCharacters = ["\r\n", "\n", "\r"]
 	private let dataBuffer: NSMutableData
-	
+
 	init() {
 		dataBuffer = NSMutableData()
 	}
-	
+
 	var currentBuffer: String? {
 		return NSString(data: dataBuffer as Data, encoding: String.Encoding.utf8.rawValue) as String?
 	}
-	
+
 	func append(data: Data?) -> [Event] {
 		guard let data = data else { return [] }
 		dataBuffer.append(data)
-		
+
 		let events = extractEventsFromBuffer().compactMap { [weak self] eventString -> Event? in
 			guard let self = self else { return nil }
 			return Event(eventString: eventString, newLineCharacters: self.validNewlineCharacters)
 		}
-		
+
 		return events
 	}
-	
+
 	private func extractEventsFromBuffer() -> [String] {
 		var events = [String]()
-		
+
 		var searchRange =  NSRange(location: 0, length: dataBuffer.length)
 		while let foundRange = searchFirstEventDelimiter(in: searchRange) {
 			// if we found a delimiter range that means that from the beggining of the buffer
 			// until the beggining of the range where the delimiter was found we have an event.
 			// The beggining of the event is: searchRange.location
 			// The lenght of the event is the position where the foundRange was found.
-			
+
 			let dataChunk = dataBuffer.subdata(
 				with: NSRange(location: searchRange.location, length: foundRange.location - searchRange.location)
 			)
-			
+
 			if let text = String(bytes: dataChunk, encoding: .utf8) {
 				events.append(text)
 			}
-			
+
 			// We move the searchRange start position (location) after the fundRange we just found and
 			searchRange.location = foundRange.location + foundRange.length
 			searchRange.length = dataBuffer.length - searchRange.location
 		}
-		
+
 		// We empty the piece of the buffer we just search in.
 		dataBuffer.replaceBytes(in: NSRange(location: 0, length: searchRange.location), withBytes: nil, length: 0)
-		
+
 		return events
 	}
-	
+
 	// This methods returns the range of the first delimiter found in the buffer. For example:
 	// If in the buffer we have: `id: event-id-1\ndata:event-data-first\n\n`
 	// This method will return the range for the `\n\n`.
 	private func searchFirstEventDelimiter(in range: NSRange) -> NSRange? {
 		let delimiters = validNewlineCharacters.map { "\($0)\($0)".data(using: String.Encoding.utf8)! }
-		
+
 		for delimiter in delimiters {
 			let foundRange = dataBuffer.range(
 				of: delimiter, options: NSData.SearchOptions(), in: range
 			)
-			
+
 			if foundRange.location != NSNotFound {
 				return foundRange
 			}
 		}
-		
+
 		return nil
 	}
 }

--- a/EventSource/EventStreamParser.swift
+++ b/EventSource/EventStreamParser.swift
@@ -9,79 +9,79 @@
 import Foundation
 
 final class EventStreamParser {
-
-    //  Events are separated by end of line. End of line can be:
-    //  \r = CR (Carriage Return) → Used as a new line character in Mac OS before X
-    //  \n = LF (Line Feed) → Used as a new line character in Unix/Mac OS X
-    //  \r\n = CR + LF → Used as a new line character in Windows
-    private let validNewlineCharacters = ["\r\n", "\n", "\r"]
-    private let dataBuffer: NSMutableData
-
-    init() {
-        dataBuffer = NSMutableData()
-    }
-
-    var currentBuffer: String? {
-        return NSString(data: dataBuffer as Data, encoding: String.Encoding.utf8.rawValue) as String?
-    }
-
-    func append(data: Data?) -> [Event] {
-        guard let data = data else { return [] }
-        dataBuffer.append(data)
-
-        let events = extractEventsFromBuffer().compactMap { [weak self] eventString -> Event? in
-            guard let self = self else { return nil }
-            return Event(eventString: eventString, newLineCharacters: self.validNewlineCharacters)
-        }
-
-        return events
-    }
-
-    private func extractEventsFromBuffer() -> [String] {
-        var events = [String]()
-
-        var searchRange =  NSRange(location: 0, length: dataBuffer.length)
-        while let foundRange = searchFirstEventDelimiter(in: searchRange) {
-            // if we found a delimiter range that means that from the beggining of the buffer
-            // until the beggining of the range where the delimiter was found we have an event.
-            // The beggining of the event is: searchRange.location
-            // The lenght of the event is the position where the foundRange was found.
-
-            let dataChunk = dataBuffer.subdata(
-                with: NSRange(location: searchRange.location, length: foundRange.location - searchRange.location)
-            )
-
-            if let text = String(bytes: dataChunk, encoding: .utf8) {
-                events.append(text)
-            }
-
-            // We move the searchRange start position (location) after the fundRange we just found and
-            searchRange.location = foundRange.location + foundRange.length
-            searchRange.length = dataBuffer.length - searchRange.location
-        }
-
-        // We empty the piece of the buffer we just search in.
-        dataBuffer.replaceBytes(in: NSRange(location: 0, length: searchRange.location), withBytes: nil, length: 0)
-
-        return events
-    }
-
-    // This methods returns the range of the first delimiter found in the buffer. For example:
-    // If in the buffer we have: `id: event-id-1\ndata:event-data-first\n\n`
-    // This method will return the range for the `\n\n`.
-    private func searchFirstEventDelimiter(in range: NSRange) -> NSRange? {
-        let delimiters = validNewlineCharacters.map { "\($0)\($0)".data(using: String.Encoding.utf8)! }
-
-        for delimiter in delimiters {
-            let foundRange = dataBuffer.range(
-                of: delimiter, options: NSData.SearchOptions(), in: range
-            )
-
-            if foundRange.location != NSNotFound {
-                return foundRange
-            }
-        }
-
-        return nil
-    }
+	
+	//  Events are separated by end of line. End of line can be:
+	//  \r = CR (Carriage Return) → Used as a new line character in Mac OS before X
+	//  \n = LF (Line Feed) → Used as a new line character in Unix/Mac OS X
+	//  \r\n = CR + LF → Used as a new line character in Windows
+	private let validNewlineCharacters = ["\r\n", "\n", "\r"]
+	private let dataBuffer: NSMutableData
+	
+	init() {
+		dataBuffer = NSMutableData()
+	}
+	
+	var currentBuffer: String? {
+		return NSString(data: dataBuffer as Data, encoding: String.Encoding.utf8.rawValue) as String?
+	}
+	
+	func append(data: Data?) -> [Event] {
+		guard let data = data else { return [] }
+		dataBuffer.append(data)
+		
+		let events = extractEventsFromBuffer().compactMap { [weak self] eventString -> Event? in
+			guard let self = self else { return nil }
+			return Event(eventString: eventString, newLineCharacters: self.validNewlineCharacters)
+		}
+		
+		return events
+	}
+	
+	private func extractEventsFromBuffer() -> [String] {
+		var events = [String]()
+		
+		var searchRange =  NSRange(location: 0, length: dataBuffer.length)
+		while let foundRange = searchFirstEventDelimiter(in: searchRange) {
+			// if we found a delimiter range that means that from the beggining of the buffer
+			// until the beggining of the range where the delimiter was found we have an event.
+			// The beggining of the event is: searchRange.location
+			// The lenght of the event is the position where the foundRange was found.
+			
+			let dataChunk = dataBuffer.subdata(
+				with: NSRange(location: searchRange.location, length: foundRange.location - searchRange.location)
+			)
+			
+			if let text = String(bytes: dataChunk, encoding: .utf8) {
+				events.append(text)
+			}
+			
+			// We move the searchRange start position (location) after the fundRange we just found and
+			searchRange.location = foundRange.location + foundRange.length
+			searchRange.length = dataBuffer.length - searchRange.location
+		}
+		
+		// We empty the piece of the buffer we just search in.
+		dataBuffer.replaceBytes(in: NSRange(location: 0, length: searchRange.location), withBytes: nil, length: 0)
+		
+		return events
+	}
+	
+	// This methods returns the range of the first delimiter found in the buffer. For example:
+	// If in the buffer we have: `id: event-id-1\ndata:event-data-first\n\n`
+	// This method will return the range for the `\n\n`.
+	private func searchFirstEventDelimiter(in range: NSRange) -> NSRange? {
+		let delimiters = validNewlineCharacters.map { "\($0)\($0)".data(using: String.Encoding.utf8)! }
+		
+		for delimiter in delimiters {
+			let foundRange = dataBuffer.range(
+				of: delimiter, options: NSData.SearchOptions(), in: range
+			)
+			
+			if foundRange.location != NSNotFound {
+				return foundRange
+			}
+		}
+		
+		return nil
+	}
 }

--- a/EventSourceSample/AppDelegate.swift
+++ b/EventSourceSample/AppDelegate.swift
@@ -11,6 +11,5 @@ import UIKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    var window: UIWindow?
-
+	var window: UIWindow?
 }

--- a/EventSourceSample/ViewController.swift
+++ b/EventSourceSample/ViewController.swift
@@ -15,12 +15,14 @@ class ViewController: UIViewController {
     @IBOutlet fileprivate weak var idLabel: UILabel!
     @IBOutlet fileprivate weak var squareConstraint: NSLayoutConstraint!
     var eventSource: EventSource?
+	
+	private let serverURL = URL(string: "http://127.0.0.1:8080/sse")!
+	private let headers = ["Authorization": "Bearer basic-auth-token"]
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let serverURL = URL(string: "http://127.0.0.1:8080/sse")!
-        eventSource = EventSource(url: serverURL, headers: ["Authorization": "Bearer basic-auth-token"])
+        eventSource = EventSource()
 
         eventSource?.onOpen { [weak self] in
             self?.status.backgroundColor = UIColor(red: 166/255, green: 226/255, blue: 46/255, alpha: 1)
@@ -35,7 +37,8 @@ class ViewController: UIViewController {
 
             let retryTime = self?.eventSource?.retryTime ?? 3000
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(retryTime)) { [weak self] in
-                self?.eventSource?.connect()
+				guard let self = self else { return }
+				self.eventSource?.connect(url: self.serverURL, headers: self.headers)
             }
         }
 
@@ -80,6 +83,6 @@ class ViewController: UIViewController {
     }
 
     @IBAction func connect(_ sender: Any) {
-        eventSource?.connect()
+		eventSource?.connect(url: serverURL, headers: headers)
     }
 }

--- a/EventSourceSample/ViewController.swift
+++ b/EventSourceSample/ViewController.swift
@@ -8,67 +8,67 @@
 
 import UIKit
 class ViewController: UIViewController {
-	
+
 	@IBOutlet fileprivate weak var status: UILabel!
 	@IBOutlet fileprivate weak var dataLabel: UILabel!
 	@IBOutlet fileprivate weak var nameLabel: UILabel!
 	@IBOutlet fileprivate weak var idLabel: UILabel!
 	@IBOutlet fileprivate weak var squareConstraint: NSLayoutConstraint!
 	var eventSource: EventSource?
-	
+
 	private let serverURL = URL(string: "http://127.0.0.1:8080/sse")!
 	private let headers = ["Authorization": "Bearer basic-auth-token"]
-	
+
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		
+
 		eventSource = EventSource()
-		
+
 		eventSource?.onOpen { [weak self] in
 			self?.status.backgroundColor = UIColor(red: 166/255, green: 226/255, blue: 46/255, alpha: 1)
 			self?.status.text = "CONNECTED"
 		}
-		
+
 		eventSource?.onComplete { [weak self] statusCode, reconnect, error in
 			self?.status.backgroundColor = UIColor(red: 249/255, green: 38/255, blue: 114/255, alpha: 1)
 			self?.status.text = "DISCONNECTED"
-			
+
 			guard reconnect ?? false else { return }
-			
+
 			let retryTime = self?.eventSource?.retryTime ?? 3000
 			DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(retryTime)) { [weak self] in
 				guard let self = self else { return }
 				self.eventSource?.connect(url: self.serverURL, headers: self.headers)
 			}
 		}
-		
+
 		eventSource?.onMessage { [weak self] id, event, data in
 			self?.updateLabels(id, event: event, data: data)
 		}
-		
+
 		eventSource?.addEventListener("user-connected") { [weak self] id, event, data in
 			self?.updateLabels(id, event: event, data: data)
 		}
 	}
-	
+
 	func updateLabels(_ id: String?, event: String?, data: String?) {
 		idLabel.text = id
 		nameLabel.text = event
 		dataLabel.text = data
 	}
-	
+
 	override func viewDidAppear(_ animated: Bool) {
 		super.viewDidAppear(animated)
-		
+
 		let finalPosition = view.frame.size.width - 50
-		
+
 		squareConstraint.constant = 0
 		view.layoutIfNeeded()
-		
+
 		let animationOptions: UIView.KeyframeAnimationOptions = [
 			UIView.KeyframeAnimationOptions.repeat, UIView.KeyframeAnimationOptions.autoreverse
 		]
-		
+
 		UIView.animateKeyframes(withDuration: 2,
 								delay: 0,
 								options: animationOptions,
@@ -77,11 +77,11 @@ class ViewController: UIViewController {
 			self.view.layoutIfNeeded()
 		}, completion: nil)
 	}
-	
+
 	@IBAction func disconnect(_ sender: Any) {
 		eventSource?.disconnect()
 	}
-	
+
 	@IBAction func connect(_ sender: Any) {
 		eventSource?.connect(url: serverURL, headers: headers)
 	}

--- a/EventSourceSample/ViewController.swift
+++ b/EventSourceSample/ViewController.swift
@@ -8,81 +8,81 @@
 
 import UIKit
 class ViewController: UIViewController {
-
-    @IBOutlet fileprivate weak var status: UILabel!
-    @IBOutlet fileprivate weak var dataLabel: UILabel!
-    @IBOutlet fileprivate weak var nameLabel: UILabel!
-    @IBOutlet fileprivate weak var idLabel: UILabel!
-    @IBOutlet fileprivate weak var squareConstraint: NSLayoutConstraint!
-    var eventSource: EventSource?
+	
+	@IBOutlet fileprivate weak var status: UILabel!
+	@IBOutlet fileprivate weak var dataLabel: UILabel!
+	@IBOutlet fileprivate weak var nameLabel: UILabel!
+	@IBOutlet fileprivate weak var idLabel: UILabel!
+	@IBOutlet fileprivate weak var squareConstraint: NSLayoutConstraint!
+	var eventSource: EventSource?
 	
 	private let serverURL = URL(string: "http://127.0.0.1:8080/sse")!
 	private let headers = ["Authorization": "Bearer basic-auth-token"]
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        eventSource = EventSource()
-
-        eventSource?.onOpen { [weak self] in
-            self?.status.backgroundColor = UIColor(red: 166/255, green: 226/255, blue: 46/255, alpha: 1)
-            self?.status.text = "CONNECTED"
-        }
-
-        eventSource?.onComplete { [weak self] statusCode, reconnect, error in
-            self?.status.backgroundColor = UIColor(red: 249/255, green: 38/255, blue: 114/255, alpha: 1)
-            self?.status.text = "DISCONNECTED"
-
-            guard reconnect ?? false else { return }
-
-            let retryTime = self?.eventSource?.retryTime ?? 3000
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(retryTime)) { [weak self] in
+	
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		
+		eventSource = EventSource()
+		
+		eventSource?.onOpen { [weak self] in
+			self?.status.backgroundColor = UIColor(red: 166/255, green: 226/255, blue: 46/255, alpha: 1)
+			self?.status.text = "CONNECTED"
+		}
+		
+		eventSource?.onComplete { [weak self] statusCode, reconnect, error in
+			self?.status.backgroundColor = UIColor(red: 249/255, green: 38/255, blue: 114/255, alpha: 1)
+			self?.status.text = "DISCONNECTED"
+			
+			guard reconnect ?? false else { return }
+			
+			let retryTime = self?.eventSource?.retryTime ?? 3000
+			DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(retryTime)) { [weak self] in
 				guard let self = self else { return }
 				self.eventSource?.connect(url: self.serverURL, headers: self.headers)
-            }
-        }
-
-        eventSource?.onMessage { [weak self] id, event, data in
-            self?.updateLabels(id, event: event, data: data)
-        }
-
-        eventSource?.addEventListener("user-connected") { [weak self] id, event, data in
-            self?.updateLabels(id, event: event, data: data)
-        }
-    }
-
-    func updateLabels(_ id: String?, event: String?, data: String?) {
-        idLabel.text = id
-        nameLabel.text = event
-        dataLabel.text = data
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        let finalPosition = view.frame.size.width - 50
-
-        squareConstraint.constant = 0
-        view.layoutIfNeeded()
-
-        let animationOptions: UIView.KeyframeAnimationOptions = [
-            UIView.KeyframeAnimationOptions.repeat, UIView.KeyframeAnimationOptions.autoreverse
-        ]
-
-        UIView.animateKeyframes(withDuration: 2,
-                                delay: 0,
-                                options: animationOptions,
-                                animations: { () in
-            self.squareConstraint.constant = finalPosition
-            self.view.layoutIfNeeded()
-        }, completion: nil)
-    }
-
-    @IBAction func disconnect(_ sender: Any) {
-        eventSource?.disconnect()
-    }
-
-    @IBAction func connect(_ sender: Any) {
+			}
+		}
+		
+		eventSource?.onMessage { [weak self] id, event, data in
+			self?.updateLabels(id, event: event, data: data)
+		}
+		
+		eventSource?.addEventListener("user-connected") { [weak self] id, event, data in
+			self?.updateLabels(id, event: event, data: data)
+		}
+	}
+	
+	func updateLabels(_ id: String?, event: String?, data: String?) {
+		idLabel.text = id
+		nameLabel.text = event
+		dataLabel.text = data
+	}
+	
+	override func viewDidAppear(_ animated: Bool) {
+		super.viewDidAppear(animated)
+		
+		let finalPosition = view.frame.size.width - 50
+		
+		squareConstraint.constant = 0
+		view.layoutIfNeeded()
+		
+		let animationOptions: UIView.KeyframeAnimationOptions = [
+			UIView.KeyframeAnimationOptions.repeat, UIView.KeyframeAnimationOptions.autoreverse
+		]
+		
+		UIView.animateKeyframes(withDuration: 2,
+								delay: 0,
+								options: animationOptions,
+								animations: { () in
+			self.squareConstraint.constant = finalPosition
+			self.view.layoutIfNeeded()
+		}, completion: nil)
+	}
+	
+	@IBAction func disconnect(_ sender: Any) {
+		eventSource?.disconnect()
+	}
+	
+	@IBAction func connect(_ sender: Any) {
 		eventSource?.connect(url: serverURL, headers: headers)
-    }
+	}
 }

--- a/EventSourceTests/EventSourceTests.swift
+++ b/EventSourceTests/EventSourceTests.swift
@@ -11,16 +11,25 @@ import XCTest
 
 class EventSourceTests: XCTestCase {
 
-    var eventSource: EventSource!
-    let url = URL(string: "https://localhost")!
+    private var eventSource: EventSource!
+	private var url: URL!
+	private var headers: [String: String]!
 
-    override func setUp() {
-        eventSource = EventSource(url: url, headers: ["header": "value"])
-    }
+	override func setUpWithError() throws {
+		try super.setUpWithError()
+		eventSource = EventSource()
+		url = try XCTUnwrap(URL(string: "https://localhost"))
+		 headers = ["header": "value"]
+	}
+	
+	override func tearDown() {
+		eventSource = nil
+		url = nil
+		headers = nil
+		super.tearDown()
+	}
 
     func testCreation() {
-        XCTAssertEqual(url, eventSource.url)
-        XCTAssertEqual(eventSource.headers, ["header": "value"])
         XCTAssertEqual(eventSource.readyState, EventSourceState.closed)
     }
 
@@ -34,7 +43,7 @@ class EventSourceTests: XCTestCase {
         XCTAssertEqual(configuration.timeoutIntervalForRequest, TimeInterval(INT_MAX))
         XCTAssertEqual(configuration.timeoutIntervalForResource, TimeInterval(INT_MAX))
         XCTAssertEqual(configuration.httpAdditionalHeaders as? [String: String], [
-            "Last-Event-Id": "event-id", "Accept": "text/event-stream", "Cache-Control": "no-cache", "header": "value"]
+            "Last-Event-Id": "event-id", "Accept": "text/event-stream", "Cache-Control": "no-cache"]
         )
     }
 
@@ -51,7 +60,7 @@ class EventSourceTests: XCTestCase {
     }
 
     func testRetryTime() {
-        eventSource.connect()
+		eventSource.connect(url: url, headers: headers)
         eventSource.readyStateOpen()
 
         let aSession = URLSession(configuration: URLSessionConfiguration.default)
@@ -132,7 +141,7 @@ class EventSourceTests: XCTestCase {
     }
 
     func testSmallEventStream() {
-        eventSource.connect()
+		eventSource.connect(url: url, headers: headers)
         eventSource.readyStateOpen()
 
         var eventsIds: [String] = []

--- a/EventSourceTests/EventSourceTests.swift
+++ b/EventSourceTests/EventSourceTests.swift
@@ -10,90 +10,90 @@ import XCTest
 @testable import EventSource
 
 class EventSourceTests: XCTestCase {
-	
+
 	private var eventSource: EventSource!
 	private var url: URL!
 	private var headers: [String: String]!
-	
+
 	override func setUpWithError() throws {
 		try super.setUpWithError()
 		eventSource = EventSource()
 		url = try XCTUnwrap(URL(string: "https://localhost"))
 		headers = ["header": "value"]
 	}
-	
+
 	override func tearDown() {
 		eventSource = nil
 		url = nil
 		headers = nil
 		super.tearDown()
 	}
-	
+
 	func testCreation() {
 		XCTAssertEqual(eventSource.readyState, EventSourceState.closed)
 	}
-	
+
 	func testDisconnect() {
 		XCTAssertEqual(eventSource.readyState, EventSourceState.closed)
 	}
-	
+
 	func testSessionConfiguration() {
 		let configuration = eventSource.sessionConfiguration(lastEventId: "event-id")
-		
+
 		XCTAssertEqual(configuration.timeoutIntervalForRequest, TimeInterval(INT_MAX))
 		XCTAssertEqual(configuration.timeoutIntervalForResource, TimeInterval(INT_MAX))
 		XCTAssertEqual(configuration.httpAdditionalHeaders as? [String: String], [
 			"Last-Event-Id": "event-id", "Accept": "text/event-stream", "Cache-Control": "no-cache"]
 		)
 	}
-	
+
 	func testAddEventListener() {
 		eventSource.addEventListener("event-name") { _, _, _ in }
 		XCTAssertEqual(eventSource.events(), ["event-name"])
 	}
-	
+
 	func testRemoveEventListener() {
 		eventSource.addEventListener("event-name") { _, _, _ in }
 		eventSource.removeEventListener("event-name")
-		
+
 		XCTAssertEqual(eventSource.events(), [])
 	}
-	
+
 	func testRetryTime() {
 		eventSource.connect(url: url, headers: headers)
 		eventSource.readyStateOpen()
-		
+
 		let aSession = URLSession(configuration: URLSessionConfiguration.default)
 		let aSessionDataTask = URLSessionDataTask()
-		
+
 		let event = """
 		id: event-id-1
 		data: event-data-first
 		retry: 1000
-		
+
 		id: event
 		"""
-		
+
 		let data = event.data(using: .utf8)!
 		eventSource.urlSession(aSession, dataTask: aSessionDataTask, didReceive: data)
 		XCTAssertEqual(eventSource.retryTime, 1000)
 	}
-	
+
 	func testOnOpen() {
 		let expectation = XCTestExpectation(description: "onOpen gets called")
-		
+
 		eventSource.onOpen {
 			XCTAssertEqual(self.eventSource.readyState, EventSourceState.open)
 			expectation.fulfill()
 		}
-		
+
 		let aSession = URLSession(configuration: URLSessionConfiguration.default)
 		let aSessionDataTask = URLSessionDataTask()
 		let urlResponse = URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
 		eventSource.urlSession(aSession, dataTask: aSessionDataTask, didReceive: urlResponse) { _ in }
 		wait(for: [expectation], timeout: 2.0)
 	}
-	
+
 	func testOnCompleteRetryTrue() {
 		let expectation = XCTestExpectation(description: "onComplete gets called")
 		eventSource.onComplete { statusCode, retry, _ in
@@ -101,14 +101,14 @@ class EventSourceTests: XCTestCase {
 			XCTAssertEqual(retry, false)
 			expectation.fulfill()
 		}
-		
+
 		let aSession = URLSession(configuration: URLSessionConfiguration.default)
 		let response =  HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: [:])
 		let dataTask = URLSessionDataTaskMock(response: response)
 		eventSource.urlSession(aSession, task: dataTask, didCompleteWithError: nil)
 		wait(for: [expectation], timeout: 2.0)
 	}
-	
+
 	func testOnCompleteRetryFalse() {
 		let expectation = XCTestExpectation(description: "onComplete gets called")
 		eventSource.onComplete { statusCode, retry, _ in
@@ -116,14 +116,14 @@ class EventSourceTests: XCTestCase {
 			XCTAssertEqual(retry, true)
 			expectation.fulfill()
 		}
-		
+
 		let aSession = URLSession(configuration: URLSessionConfiguration.default)
 		let response =  HTTPURLResponse(url: url, statusCode: 250, httpVersion: nil, headerFields: [:])
 		let dataTask = URLSessionDataTaskMock(response: response)
 		eventSource.urlSession(aSession, task: dataTask, didCompleteWithError: nil)
 		wait(for: [expectation], timeout: 2.0)
 	}
-	
+
 	func testOnCompleteError() {
 		let expectation = XCTestExpectation(description: "onComplete gets called")
 		eventSource.onComplete { statusCode, retry, error in
@@ -132,62 +132,62 @@ class EventSourceTests: XCTestCase {
 			XCTAssertNil(statusCode)
 			expectation.fulfill()
 		}
-		
+
 		let aSession = URLSession(configuration: URLSessionConfiguration.default)
 		let dataTask = URLSessionDataTaskMock(response: nil)
 		let error = NSError(domain: "", code: -1, userInfo: [:])
 		eventSource.urlSession(aSession, task: dataTask, didCompleteWithError: error)
 		wait(for: [expectation], timeout: 2.0)
 	}
-	
+
 	func testSmallEventStream() {
 		eventSource.connect(url: url, headers: headers)
 		eventSource.readyStateOpen()
-		
+
 		var eventsIds: [String] = []
 		var eventNames: [String] = []
 		var eventDatas: [String] = []
-		
+
 		let exp = self.expectation(description: "onMessage gets called")
 		eventSource.onMessage { eventId, eventName, eventData in
 			eventsIds.append(eventId ?? "")
 			eventNames.append(eventName ?? "")
 			eventDatas.append(eventData ?? "")
-			
+
 			if(eventsIds.count == 3) {
 				exp.fulfill()
 			}
 		}
-		
+
 		let eventsString = """
 		id: event-id-1
 		data: event-data-first
-		
+
 		id: event-id-2
 		data: event-data-second
-		
+
 		id: event-id-3
 		data: event-data-third
-		
-		
+
+
 		"""
-		
+
 		let aSession = URLSession(configuration: URLSessionConfiguration.default)
 		let aSessionDataTask = URLSessionDataTask()
 		let data = eventsString.data(using: .utf8)!
 		eventSource.urlSession(aSession, dataTask: aSessionDataTask, didReceive: data)
-		
+
 		waitForExpectations(timeout: 2) { _ in
 			XCTAssertEqual(eventsIds, ["event-id-1", "event-id-2", "event-id-3"])
 			XCTAssertEqual(eventNames, ["message", "message", "message"])
 			XCTAssertEqual(eventsIds, ["event-id-1", "event-id-2", "event-id-3"])
 		}
 	}
-	
+
 	func testDisconnet() {
 		eventSource.readyStateOpen()
 		eventSource.disconnect()
-		
+
 		XCTAssertEqual(eventSource.readyState, .closed)
 	}
 }

--- a/EventSourceTests/EventSourceTests.swift
+++ b/EventSourceTests/EventSourceTests.swift
@@ -10,16 +10,16 @@ import XCTest
 @testable import EventSource
 
 class EventSourceTests: XCTestCase {
-
-    private var eventSource: EventSource!
+	
+	private var eventSource: EventSource!
 	private var url: URL!
 	private var headers: [String: String]!
-
+	
 	override func setUpWithError() throws {
 		try super.setUpWithError()
 		eventSource = EventSource()
 		url = try XCTUnwrap(URL(string: "https://localhost"))
-		 headers = ["header": "value"]
+		headers = ["header": "value"]
 	}
 	
 	override func tearDown() {
@@ -28,166 +28,166 @@ class EventSourceTests: XCTestCase {
 		headers = nil
 		super.tearDown()
 	}
-
-    func testCreation() {
-        XCTAssertEqual(eventSource.readyState, EventSourceState.closed)
-    }
-
-    func testDisconnect() {
-        XCTAssertEqual(eventSource.readyState, EventSourceState.closed)
-    }
-
-    func testSessionConfiguration() {
-        let configuration = eventSource.sessionConfiguration(lastEventId: "event-id")
-
-        XCTAssertEqual(configuration.timeoutIntervalForRequest, TimeInterval(INT_MAX))
-        XCTAssertEqual(configuration.timeoutIntervalForResource, TimeInterval(INT_MAX))
-        XCTAssertEqual(configuration.httpAdditionalHeaders as? [String: String], [
-            "Last-Event-Id": "event-id", "Accept": "text/event-stream", "Cache-Control": "no-cache"]
-        )
-    }
-
-    func testAddEventListener() {
-        eventSource.addEventListener("event-name") { _, _, _ in }
-        XCTAssertEqual(eventSource.events(), ["event-name"])
-    }
-
-    func testRemoveEventListener() {
-        eventSource.addEventListener("event-name") { _, _, _ in }
-        eventSource.removeEventListener("event-name")
-
-        XCTAssertEqual(eventSource.events(), [])
-    }
-
-    func testRetryTime() {
+	
+	func testCreation() {
+		XCTAssertEqual(eventSource.readyState, EventSourceState.closed)
+	}
+	
+	func testDisconnect() {
+		XCTAssertEqual(eventSource.readyState, EventSourceState.closed)
+	}
+	
+	func testSessionConfiguration() {
+		let configuration = eventSource.sessionConfiguration(lastEventId: "event-id")
+		
+		XCTAssertEqual(configuration.timeoutIntervalForRequest, TimeInterval(INT_MAX))
+		XCTAssertEqual(configuration.timeoutIntervalForResource, TimeInterval(INT_MAX))
+		XCTAssertEqual(configuration.httpAdditionalHeaders as? [String: String], [
+			"Last-Event-Id": "event-id", "Accept": "text/event-stream", "Cache-Control": "no-cache"]
+		)
+	}
+	
+	func testAddEventListener() {
+		eventSource.addEventListener("event-name") { _, _, _ in }
+		XCTAssertEqual(eventSource.events(), ["event-name"])
+	}
+	
+	func testRemoveEventListener() {
+		eventSource.addEventListener("event-name") { _, _, _ in }
+		eventSource.removeEventListener("event-name")
+		
+		XCTAssertEqual(eventSource.events(), [])
+	}
+	
+	func testRetryTime() {
 		eventSource.connect(url: url, headers: headers)
-        eventSource.readyStateOpen()
-
-        let aSession = URLSession(configuration: URLSessionConfiguration.default)
-        let aSessionDataTask = URLSessionDataTask()
-
-        let event = """
-        id: event-id-1
-        data: event-data-first
-        retry: 1000
-
-        id: event
-        """
-
-        let data = event.data(using: .utf8)!
-        eventSource.urlSession(aSession, dataTask: aSessionDataTask, didReceive: data)
-        XCTAssertEqual(eventSource.retryTime, 1000)
-    }
-
-    func testOnOpen() {
-        let expectation = XCTestExpectation(description: "onOpen gets called")
-
-        eventSource.onOpen {
-            XCTAssertEqual(self.eventSource.readyState, EventSourceState.open)
-            expectation.fulfill()
-        }
-
-        let aSession = URLSession(configuration: URLSessionConfiguration.default)
-        let aSessionDataTask = URLSessionDataTask()
-        let urlResponse = URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
-        eventSource.urlSession(aSession, dataTask: aSessionDataTask, didReceive: urlResponse) { _ in }
-        wait(for: [expectation], timeout: 2.0)
-    }
-
-    func testOnCompleteRetryTrue() {
-        let expectation = XCTestExpectation(description: "onComplete gets called")
-        eventSource.onComplete { statusCode, retry, _ in
-            XCTAssertEqual(statusCode, 200)
-            XCTAssertEqual(retry, false)
-            expectation.fulfill()
-        }
-
-        let aSession = URLSession(configuration: URLSessionConfiguration.default)
-        let response =  HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: [:])
-        let dataTask = URLSessionDataTaskMock(response: response)
-        eventSource.urlSession(aSession, task: dataTask, didCompleteWithError: nil)
-        wait(for: [expectation], timeout: 2.0)
-    }
-
-    func testOnCompleteRetryFalse() {
-        let expectation = XCTestExpectation(description: "onComplete gets called")
-        eventSource.onComplete { statusCode, retry, _ in
-            XCTAssertEqual(statusCode, 250)
-            XCTAssertEqual(retry, true)
-            expectation.fulfill()
-        }
-
-        let aSession = URLSession(configuration: URLSessionConfiguration.default)
-        let response =  HTTPURLResponse(url: url, statusCode: 250, httpVersion: nil, headerFields: [:])
-        let dataTask = URLSessionDataTaskMock(response: response)
-        eventSource.urlSession(aSession, task: dataTask, didCompleteWithError: nil)
-        wait(for: [expectation], timeout: 2.0)
-    }
-
-    func testOnCompleteError() {
-        let expectation = XCTestExpectation(description: "onComplete gets called")
-        eventSource.onComplete { statusCode, retry, error in
-            XCTAssertNotNil(error)
-            XCTAssertNil(retry)
-            XCTAssertNil(statusCode)
-            expectation.fulfill()
-        }
-
-        let aSession = URLSession(configuration: URLSessionConfiguration.default)
-        let dataTask = URLSessionDataTaskMock(response: nil)
-        let error = NSError(domain: "", code: -1, userInfo: [:])
-        eventSource.urlSession(aSession, task: dataTask, didCompleteWithError: error)
-        wait(for: [expectation], timeout: 2.0)
-    }
-
-    func testSmallEventStream() {
+		eventSource.readyStateOpen()
+		
+		let aSession = URLSession(configuration: URLSessionConfiguration.default)
+		let aSessionDataTask = URLSessionDataTask()
+		
+		let event = """
+		id: event-id-1
+		data: event-data-first
+		retry: 1000
+		
+		id: event
+		"""
+		
+		let data = event.data(using: .utf8)!
+		eventSource.urlSession(aSession, dataTask: aSessionDataTask, didReceive: data)
+		XCTAssertEqual(eventSource.retryTime, 1000)
+	}
+	
+	func testOnOpen() {
+		let expectation = XCTestExpectation(description: "onOpen gets called")
+		
+		eventSource.onOpen {
+			XCTAssertEqual(self.eventSource.readyState, EventSourceState.open)
+			expectation.fulfill()
+		}
+		
+		let aSession = URLSession(configuration: URLSessionConfiguration.default)
+		let aSessionDataTask = URLSessionDataTask()
+		let urlResponse = URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+		eventSource.urlSession(aSession, dataTask: aSessionDataTask, didReceive: urlResponse) { _ in }
+		wait(for: [expectation], timeout: 2.0)
+	}
+	
+	func testOnCompleteRetryTrue() {
+		let expectation = XCTestExpectation(description: "onComplete gets called")
+		eventSource.onComplete { statusCode, retry, _ in
+			XCTAssertEqual(statusCode, 200)
+			XCTAssertEqual(retry, false)
+			expectation.fulfill()
+		}
+		
+		let aSession = URLSession(configuration: URLSessionConfiguration.default)
+		let response =  HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: [:])
+		let dataTask = URLSessionDataTaskMock(response: response)
+		eventSource.urlSession(aSession, task: dataTask, didCompleteWithError: nil)
+		wait(for: [expectation], timeout: 2.0)
+	}
+	
+	func testOnCompleteRetryFalse() {
+		let expectation = XCTestExpectation(description: "onComplete gets called")
+		eventSource.onComplete { statusCode, retry, _ in
+			XCTAssertEqual(statusCode, 250)
+			XCTAssertEqual(retry, true)
+			expectation.fulfill()
+		}
+		
+		let aSession = URLSession(configuration: URLSessionConfiguration.default)
+		let response =  HTTPURLResponse(url: url, statusCode: 250, httpVersion: nil, headerFields: [:])
+		let dataTask = URLSessionDataTaskMock(response: response)
+		eventSource.urlSession(aSession, task: dataTask, didCompleteWithError: nil)
+		wait(for: [expectation], timeout: 2.0)
+	}
+	
+	func testOnCompleteError() {
+		let expectation = XCTestExpectation(description: "onComplete gets called")
+		eventSource.onComplete { statusCode, retry, error in
+			XCTAssertNotNil(error)
+			XCTAssertNil(retry)
+			XCTAssertNil(statusCode)
+			expectation.fulfill()
+		}
+		
+		let aSession = URLSession(configuration: URLSessionConfiguration.default)
+		let dataTask = URLSessionDataTaskMock(response: nil)
+		let error = NSError(domain: "", code: -1, userInfo: [:])
+		eventSource.urlSession(aSession, task: dataTask, didCompleteWithError: error)
+		wait(for: [expectation], timeout: 2.0)
+	}
+	
+	func testSmallEventStream() {
 		eventSource.connect(url: url, headers: headers)
-        eventSource.readyStateOpen()
-
-        var eventsIds: [String] = []
-        var eventNames: [String] = []
-        var eventDatas: [String] = []
-
-        let exp = self.expectation(description: "onMessage gets called")
-        eventSource.onMessage { eventId, eventName, eventData in
-            eventsIds.append(eventId ?? "")
-            eventNames.append(eventName ?? "")
-            eventDatas.append(eventData ?? "")
-
-            if(eventsIds.count == 3) {
-                exp.fulfill()
-            }
-        }
-
-        let eventsString = """
-        id: event-id-1
-        data: event-data-first
-
-        id: event-id-2
-        data: event-data-second
-
-        id: event-id-3
-        data: event-data-third
-
-
-        """
-
-        let aSession = URLSession(configuration: URLSessionConfiguration.default)
-        let aSessionDataTask = URLSessionDataTask()
-        let data = eventsString.data(using: .utf8)!
-        eventSource.urlSession(aSession, dataTask: aSessionDataTask, didReceive: data)
-
-        waitForExpectations(timeout: 2) { _ in
-            XCTAssertEqual(eventsIds, ["event-id-1", "event-id-2", "event-id-3"])
-            XCTAssertEqual(eventNames, ["message", "message", "message"])
-            XCTAssertEqual(eventsIds, ["event-id-1", "event-id-2", "event-id-3"])
-        }
-    }
-
-    func testDisconnet() {
-        eventSource.readyStateOpen()
-        eventSource.disconnect()
-
-        XCTAssertEqual(eventSource.readyState, .closed)
-    }
+		eventSource.readyStateOpen()
+		
+		var eventsIds: [String] = []
+		var eventNames: [String] = []
+		var eventDatas: [String] = []
+		
+		let exp = self.expectation(description: "onMessage gets called")
+		eventSource.onMessage { eventId, eventName, eventData in
+			eventsIds.append(eventId ?? "")
+			eventNames.append(eventName ?? "")
+			eventDatas.append(eventData ?? "")
+			
+			if(eventsIds.count == 3) {
+				exp.fulfill()
+			}
+		}
+		
+		let eventsString = """
+		id: event-id-1
+		data: event-data-first
+		
+		id: event-id-2
+		data: event-data-second
+		
+		id: event-id-3
+		data: event-data-third
+		
+		
+		"""
+		
+		let aSession = URLSession(configuration: URLSessionConfiguration.default)
+		let aSessionDataTask = URLSessionDataTask()
+		let data = eventsString.data(using: .utf8)!
+		eventSource.urlSession(aSession, dataTask: aSessionDataTask, didReceive: data)
+		
+		waitForExpectations(timeout: 2) { _ in
+			XCTAssertEqual(eventsIds, ["event-id-1", "event-id-2", "event-id-3"])
+			XCTAssertEqual(eventNames, ["message", "message", "message"])
+			XCTAssertEqual(eventsIds, ["event-id-1", "event-id-2", "event-id-3"])
+		}
+	}
+	
+	func testDisconnet() {
+		eventSource.readyStateOpen()
+		eventSource.disconnect()
+		
+		XCTAssertEqual(eventSource.readyState, .closed)
+	}
 }

--- a/EventSourceTests/EventStreamParserTests.swift
+++ b/EventSourceTests/EventStreamParserTests.swift
@@ -11,50 +11,50 @@ import XCTest
 @testable import EventSource
 
 class EventStreamParserTests: XCTestCase {
-	
+
 	func testExtractingEvents() {
 		let eventParser = EventStreamParser()
 		let eventsString = """
 		id: event-id-1
 		data: event-data-first
-		
+
 		id: event-id-2
 		data: event-data-second
-		
+
 		id: event-id-3
 		data: event-data-third
 		"""
-		
+
 		let events = eventParser.append(data: eventsString.data(using: .utf8))
 		XCTAssertEqual(events.count, 2)
 	}
-	
+
 	func testExtractingSplittedEvents() {
 		let eventParser = EventStreamParser()
 		let firstEventsStringPiece = """
 		id: event-id-1
 		data: event-data-first
-		
+
 		id: event
 		"""
-		
+
 		var events = eventParser.append(data: firstEventsStringPiece.data(using: .utf8))
 		XCTAssertEqual(events.count, 1)
-		
+
 		let secondEventsStringPiece = """
 		-id-2
 		data: event-data-second
-		
+
 		id: event-id-3
 		data: event-data-third
-		
-		
+
+
 		"""
-		
+
 		events = eventParser.append(data: secondEventsStringPiece.data(using: .utf8))
 		XCTAssertEqual(events.count, 2)
 	}
-	
+
 	// The following test streams are the samples introduced in the https://www.w3.org/TR/eventsource/ from section 7
 	func testFirstW3StreamSample() {
 		let eventParser = EventStreamParser()
@@ -62,20 +62,20 @@ class EventStreamParserTests: XCTestCase {
 		data: YHOO
 		data: +2
 		data: 10
-		
-		
+
+
 		"""
-		
+
 		let events = eventParser.append(data: eventString.data(using: .utf8))
 		XCTAssertEqual(events.count, 1)
-		
+
 		let event = events.first!
 		XCTAssertEqual(event.id, nil)
 		XCTAssertEqual(event.event, nil)
 		XCTAssertEqual(event.retryTime, nil)
 		XCTAssertEqual(event.data, "YHOO\n+2\n10")
 	}
-	
+
 	// The first block has just a comment, and will fire nothing.
 	// The second block has two fields with names "data" and "id" respectively; an event will be fired for this block.
 	// The third block fires an event.
@@ -84,33 +84,33 @@ class EventStreamParserTests: XCTestCase {
 		let eventParser = EventStreamParser()
 		let eventString = """
 		: test stream
-		
+
 		data: first event
 		id: 1
-		
+
 		data:second event
 		id
-		
+
 		data:  third event
-		
+
 		"""
-		
+
 		let events = eventParser.append(data: eventString.data(using: .utf8))
 		XCTAssertEqual(events.count, 2)
-		
+
 		let firstEvent = events[0]
 		XCTAssertEqual(firstEvent.id, "1")
 		XCTAssertEqual(firstEvent.event, nil)
 		XCTAssertEqual(firstEvent.data, "first event")
 		XCTAssertEqual(firstEvent.retryTime, nil)
-		
+
 		let secondEvent = events[1]
 		XCTAssertEqual(secondEvent.id, "")
 		XCTAssertEqual(secondEvent.event, nil)
 		XCTAssertEqual(secondEvent.data, "second event")
 		XCTAssertEqual(secondEvent.retryTime, nil)
 	}
-	
+
 	// The first block fires an event with the data set to the empty string.
 	// The middle block fires an event with the data set to a single newline character.
 	// The last block fires an event with the data set to empty string.
@@ -118,90 +118,90 @@ class EventStreamParserTests: XCTestCase {
 		let eventParser = EventStreamParser()
 		let eventString = """
 		data
-		
+
 		data
 		data
-		
+
 		data:
-		
-		
+
+
 		"""
-		
+
 		let events = eventParser.append(data: eventString.data(using: .utf8))
 		XCTAssertEqual(events.count, 3)
-		
+
 		let firstEvent = events[0]
 		XCTAssertEqual(firstEvent.id, nil)
 		XCTAssertEqual(firstEvent.event, nil)
 		XCTAssertEqual(firstEvent.data, "")
 		XCTAssertEqual(firstEvent.retryTime, nil)
-		
+
 		let secondEvent = events[1]
 		XCTAssertEqual(secondEvent.id, nil)
 		XCTAssertEqual(secondEvent.event, nil)
 		XCTAssertEqual(secondEvent.data, "\n")
 		XCTAssertEqual(secondEvent.retryTime, nil)
-		
+
 		let thirdEvent = events[2]
 		XCTAssertEqual(thirdEvent.id, nil)
 		XCTAssertEqual(thirdEvent.event, nil)
 		XCTAssertEqual(thirdEvent.data, "")
 		XCTAssertEqual(thirdEvent.retryTime, nil)
 	}
-	
+
 	// The following stream fires two identical events:
 	func testForthW3StreamSample() {
 		let eventParser = EventStreamParser()
 		let eventString = """
 		data:test
-		
+
 		data: test
-		
-		
+
+
 		"""
-		
+
 		let events = eventParser.append(data: eventString.data(using: .utf8))
 		XCTAssertEqual(events.count, 2)
-		
+
 		let firstEvent = events[0]
 		XCTAssertEqual(firstEvent.id, nil)
 		XCTAssertEqual(firstEvent.event, nil)
 		XCTAssertEqual(firstEvent.data, "test")
 		XCTAssertEqual(firstEvent.retryTime, nil)
-		
+
 		let secondEvent = events[1]
 		XCTAssertEqual(secondEvent.id, nil)
 		XCTAssertEqual(secondEvent.event, nil)
 		XCTAssertEqual(secondEvent.data, "test")
 		XCTAssertEqual(secondEvent.retryTime, nil)
 	}
-	
+
 	func testEventAfterCommentedLine() {
 		let eventParser = EventStreamParser()
 		let eventString = """
 			:thump
 			event: update
 			data: data-from-the-event
-		
-		
+
+
 		"""
-		
+
 		let events = eventParser.append(data: eventString.data(using: .utf8))
 		XCTAssertEqual(events.count, 1)
-		
+
 		let firstEvent = events[0]
 		XCTAssertEqual(firstEvent.id, nil)
 		XCTAssertEqual(firstEvent.event, "update")
 		XCTAssertEqual(firstEvent.data, "data-from-the-event")
 		XCTAssertEqual(firstEvent.retryTime, nil)
 	}
-	
+
 	func testCurrentBuffer() {
 		let eventParser = EventStreamParser()
 		let eventString = """
 		-id-2
 		data: event-data-second
-		
+
 		"""
 		_ = eventParser.append(data: eventString.data(using: .utf8))
 		XCTAssertEqual(eventParser.currentBuffer, eventString)

--- a/EventSourceTests/EventStreamParserTests.swift
+++ b/EventSourceTests/EventStreamParserTests.swift
@@ -11,199 +11,199 @@ import XCTest
 @testable import EventSource
 
 class EventStreamParserTests: XCTestCase {
-
-    func testExtractingEvents() {
-        let eventParser = EventStreamParser()
-        let eventsString = """
-        id: event-id-1
-        data: event-data-first
-
-        id: event-id-2
-        data: event-data-second
-
-        id: event-id-3
-        data: event-data-third
-        """
-
-        let events = eventParser.append(data: eventsString.data(using: .utf8))
-        XCTAssertEqual(events.count, 2)
-    }
-
-    func testExtractingSplittedEvents() {
-        let eventParser = EventStreamParser()
-        let firstEventsStringPiece = """
-        id: event-id-1
-        data: event-data-first
-
-        id: event
-        """
-
-        var events = eventParser.append(data: firstEventsStringPiece.data(using: .utf8))
-        XCTAssertEqual(events.count, 1)
-
-        let secondEventsStringPiece = """
-        -id-2
-        data: event-data-second
-
-        id: event-id-3
-        data: event-data-third
-
-
-        """
-
-        events = eventParser.append(data: secondEventsStringPiece.data(using: .utf8))
-        XCTAssertEqual(events.count, 2)
-    }
-
-    // The following test streams are the samples introduced in the https://www.w3.org/TR/eventsource/ from section 7
-    func testFirstW3StreamSample() {
-        let eventParser = EventStreamParser()
-        let eventString = """
-        data: YHOO
-        data: +2
-        data: 10
-
-
-        """
-
-        let events = eventParser.append(data: eventString.data(using: .utf8))
-        XCTAssertEqual(events.count, 1)
-
-        let event = events.first!
-        XCTAssertEqual(event.id, nil)
-        XCTAssertEqual(event.event, nil)
-        XCTAssertEqual(event.retryTime, nil)
-        XCTAssertEqual(event.data, "YHOO\n+2\n10")
-    }
-
-    // The first block has just a comment, and will fire nothing.
-    // The second block has two fields with names "data" and "id" respectively; an event will be fired for this block.
-    // The third block fires an event.
-    // The last block is not fired as a new breakline is still missing to be parsed.
-    func testSecondW3StreamSample() {
-        let eventParser = EventStreamParser()
-        let eventString = """
-        : test stream
-
-        data: first event
-        id: 1
-
-        data:second event
-        id
-
-        data:  third event
-
-        """
-
-        let events = eventParser.append(data: eventString.data(using: .utf8))
-        XCTAssertEqual(events.count, 2)
-
-        let firstEvent = events[0]
-        XCTAssertEqual(firstEvent.id, "1")
-        XCTAssertEqual(firstEvent.event, nil)
-        XCTAssertEqual(firstEvent.data, "first event")
-        XCTAssertEqual(firstEvent.retryTime, nil)
-
-        let secondEvent = events[1]
-        XCTAssertEqual(secondEvent.id, "")
-        XCTAssertEqual(secondEvent.event, nil)
-        XCTAssertEqual(secondEvent.data, "second event")
-        XCTAssertEqual(secondEvent.retryTime, nil)
-    }
-
-    // The first block fires an event with the data set to the empty string.
-    // The middle block fires an event with the data set to a single newline character.
-    // The last block fires an event with the data set to empty string.
-    func testThirdW3StreamSample() {
-        let eventParser = EventStreamParser()
-        let eventString = """
-        data
-
-        data
-        data
-
-        data:
-
-
-        """
-
-        let events = eventParser.append(data: eventString.data(using: .utf8))
-        XCTAssertEqual(events.count, 3)
-
-        let firstEvent = events[0]
-        XCTAssertEqual(firstEvent.id, nil)
-        XCTAssertEqual(firstEvent.event, nil)
-        XCTAssertEqual(firstEvent.data, "")
-        XCTAssertEqual(firstEvent.retryTime, nil)
-
-        let secondEvent = events[1]
-        XCTAssertEqual(secondEvent.id, nil)
-        XCTAssertEqual(secondEvent.event, nil)
-        XCTAssertEqual(secondEvent.data, "\n")
-        XCTAssertEqual(secondEvent.retryTime, nil)
-
-        let thirdEvent = events[2]
-        XCTAssertEqual(thirdEvent.id, nil)
-        XCTAssertEqual(thirdEvent.event, nil)
-        XCTAssertEqual(thirdEvent.data, "")
-        XCTAssertEqual(thirdEvent.retryTime, nil)
-    }
-
-    // The following stream fires two identical events:
-    func testForthW3StreamSample() {
-        let eventParser = EventStreamParser()
-        let eventString = """
-        data:test
-
-        data: test
-
-
-        """
-
-        let events = eventParser.append(data: eventString.data(using: .utf8))
-        XCTAssertEqual(events.count, 2)
-
-        let firstEvent = events[0]
-        XCTAssertEqual(firstEvent.id, nil)
-        XCTAssertEqual(firstEvent.event, nil)
-        XCTAssertEqual(firstEvent.data, "test")
-        XCTAssertEqual(firstEvent.retryTime, nil)
-
-        let secondEvent = events[1]
-        XCTAssertEqual(secondEvent.id, nil)
-        XCTAssertEqual(secondEvent.event, nil)
-        XCTAssertEqual(secondEvent.data, "test")
-        XCTAssertEqual(secondEvent.retryTime, nil)
-    }
-
-    func testEventAfterCommentedLine() {
-        let eventParser = EventStreamParser()
-        let eventString = """
-            :thump
-            event: update
-            data: data-from-the-event
-
-
-        """
-
-        let events = eventParser.append(data: eventString.data(using: .utf8))
-        XCTAssertEqual(events.count, 1)
-
-        let firstEvent = events[0]
-        XCTAssertEqual(firstEvent.id, nil)
-        XCTAssertEqual(firstEvent.event, "update")
-        XCTAssertEqual(firstEvent.data, "data-from-the-event")
-        XCTAssertEqual(firstEvent.retryTime, nil)
-    }
-
-    func testCurrentBuffer() {
-        let eventParser = EventStreamParser()
-        let eventString = """
-        -id-2
-        data: event-data-second
-
-        """
-        _ = eventParser.append(data: eventString.data(using: .utf8))
-        XCTAssertEqual(eventParser.currentBuffer, eventString)
-    }
+	
+	func testExtractingEvents() {
+		let eventParser = EventStreamParser()
+		let eventsString = """
+		id: event-id-1
+		data: event-data-first
+		
+		id: event-id-2
+		data: event-data-second
+		
+		id: event-id-3
+		data: event-data-third
+		"""
+		
+		let events = eventParser.append(data: eventsString.data(using: .utf8))
+		XCTAssertEqual(events.count, 2)
+	}
+	
+	func testExtractingSplittedEvents() {
+		let eventParser = EventStreamParser()
+		let firstEventsStringPiece = """
+		id: event-id-1
+		data: event-data-first
+		
+		id: event
+		"""
+		
+		var events = eventParser.append(data: firstEventsStringPiece.data(using: .utf8))
+		XCTAssertEqual(events.count, 1)
+		
+		let secondEventsStringPiece = """
+		-id-2
+		data: event-data-second
+		
+		id: event-id-3
+		data: event-data-third
+		
+		
+		"""
+		
+		events = eventParser.append(data: secondEventsStringPiece.data(using: .utf8))
+		XCTAssertEqual(events.count, 2)
+	}
+	
+	// The following test streams are the samples introduced in the https://www.w3.org/TR/eventsource/ from section 7
+	func testFirstW3StreamSample() {
+		let eventParser = EventStreamParser()
+		let eventString = """
+		data: YHOO
+		data: +2
+		data: 10
+		
+		
+		"""
+		
+		let events = eventParser.append(data: eventString.data(using: .utf8))
+		XCTAssertEqual(events.count, 1)
+		
+		let event = events.first!
+		XCTAssertEqual(event.id, nil)
+		XCTAssertEqual(event.event, nil)
+		XCTAssertEqual(event.retryTime, nil)
+		XCTAssertEqual(event.data, "YHOO\n+2\n10")
+	}
+	
+	// The first block has just a comment, and will fire nothing.
+	// The second block has two fields with names "data" and "id" respectively; an event will be fired for this block.
+	// The third block fires an event.
+	// The last block is not fired as a new breakline is still missing to be parsed.
+	func testSecondW3StreamSample() {
+		let eventParser = EventStreamParser()
+		let eventString = """
+		: test stream
+		
+		data: first event
+		id: 1
+		
+		data:second event
+		id
+		
+		data:  third event
+		
+		"""
+		
+		let events = eventParser.append(data: eventString.data(using: .utf8))
+		XCTAssertEqual(events.count, 2)
+		
+		let firstEvent = events[0]
+		XCTAssertEqual(firstEvent.id, "1")
+		XCTAssertEqual(firstEvent.event, nil)
+		XCTAssertEqual(firstEvent.data, "first event")
+		XCTAssertEqual(firstEvent.retryTime, nil)
+		
+		let secondEvent = events[1]
+		XCTAssertEqual(secondEvent.id, "")
+		XCTAssertEqual(secondEvent.event, nil)
+		XCTAssertEqual(secondEvent.data, "second event")
+		XCTAssertEqual(secondEvent.retryTime, nil)
+	}
+	
+	// The first block fires an event with the data set to the empty string.
+	// The middle block fires an event with the data set to a single newline character.
+	// The last block fires an event with the data set to empty string.
+	func testThirdW3StreamSample() {
+		let eventParser = EventStreamParser()
+		let eventString = """
+		data
+		
+		data
+		data
+		
+		data:
+		
+		
+		"""
+		
+		let events = eventParser.append(data: eventString.data(using: .utf8))
+		XCTAssertEqual(events.count, 3)
+		
+		let firstEvent = events[0]
+		XCTAssertEqual(firstEvent.id, nil)
+		XCTAssertEqual(firstEvent.event, nil)
+		XCTAssertEqual(firstEvent.data, "")
+		XCTAssertEqual(firstEvent.retryTime, nil)
+		
+		let secondEvent = events[1]
+		XCTAssertEqual(secondEvent.id, nil)
+		XCTAssertEqual(secondEvent.event, nil)
+		XCTAssertEqual(secondEvent.data, "\n")
+		XCTAssertEqual(secondEvent.retryTime, nil)
+		
+		let thirdEvent = events[2]
+		XCTAssertEqual(thirdEvent.id, nil)
+		XCTAssertEqual(thirdEvent.event, nil)
+		XCTAssertEqual(thirdEvent.data, "")
+		XCTAssertEqual(thirdEvent.retryTime, nil)
+	}
+	
+	// The following stream fires two identical events:
+	func testForthW3StreamSample() {
+		let eventParser = EventStreamParser()
+		let eventString = """
+		data:test
+		
+		data: test
+		
+		
+		"""
+		
+		let events = eventParser.append(data: eventString.data(using: .utf8))
+		XCTAssertEqual(events.count, 2)
+		
+		let firstEvent = events[0]
+		XCTAssertEqual(firstEvent.id, nil)
+		XCTAssertEqual(firstEvent.event, nil)
+		XCTAssertEqual(firstEvent.data, "test")
+		XCTAssertEqual(firstEvent.retryTime, nil)
+		
+		let secondEvent = events[1]
+		XCTAssertEqual(secondEvent.id, nil)
+		XCTAssertEqual(secondEvent.event, nil)
+		XCTAssertEqual(secondEvent.data, "test")
+		XCTAssertEqual(secondEvent.retryTime, nil)
+	}
+	
+	func testEventAfterCommentedLine() {
+		let eventParser = EventStreamParser()
+		let eventString = """
+			:thump
+			event: update
+			data: data-from-the-event
+		
+		
+		"""
+		
+		let events = eventParser.append(data: eventString.data(using: .utf8))
+		XCTAssertEqual(events.count, 1)
+		
+		let firstEvent = events[0]
+		XCTAssertEqual(firstEvent.id, nil)
+		XCTAssertEqual(firstEvent.event, "update")
+		XCTAssertEqual(firstEvent.data, "data-from-the-event")
+		XCTAssertEqual(firstEvent.retryTime, nil)
+	}
+	
+	func testCurrentBuffer() {
+		let eventParser = EventStreamParser()
+		let eventString = """
+		-id-2
+		data: event-data-second
+		
+		"""
+		_ = eventParser.append(data: eventString.data(using: .utf8))
+		XCTAssertEqual(eventParser.currentBuffer, eventString)
+	}
 }

--- a/EventSourceTests/EventTests.swift
+++ b/EventSourceTests/EventTests.swift
@@ -11,144 +11,144 @@ import XCTest
 @testable import EventSource
 
 class EventTests: XCTestCase {
-    let newLineCharacters = ["\r\n", "\n", "\r"]
+	let newLineCharacters = ["\r\n", "\n", "\r"]
 
-    func testIgnoreComment() {
-        var event = Event(eventString: ":retry", newLineCharacters: newLineCharacters)
-        XCTAssertNil(event)
+	func testIgnoreComment() {
+		var event = Event(eventString: ":retry", newLineCharacters: newLineCharacters)
+		XCTAssertNil(event)
 
-        event = Event(eventString: ": retry", newLineCharacters: newLineCharacters)
-        XCTAssertNil(event)
-    }
+		event = Event(eventString: ": retry", newLineCharacters: newLineCharacters)
+		XCTAssertNil(event)
+	}
 
-    func testRetryEvent() {
-        let eventsString = """
-        retry: 5000
-        """
+	func testRetryEvent() {
+		let eventsString = """
+		retry: 5000
+		"""
 
-        let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
-        XCTAssertEqual(event?.retryTime, 5000)
-    }
+		let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
+		XCTAssertEqual(event?.retryTime, 5000)
+	}
 
-    func testRetryEventWrongTime() {
-        let eventsString = """
-        retry: this is a wrong value
-        """
+	func testRetryEventWrongTime() {
+		let eventsString = """
+		retry: this is a wrong value
+		"""
 
-        let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
-        XCTAssertEqual(event?.retryTime, nil)
-    }
+		let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
+		XCTAssertEqual(event?.retryTime, nil)
+	}
 
-    func testFullBasicEvent() {
-        let eventsString = """
-        id: event-id-1
-        data: event-data-first
-        event: testing event name
-        """
+	func testFullBasicEvent() {
+		let eventsString = """
+		id: event-id-1
+		data: event-data-first
+		event: testing event name
+		"""
 
-        let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
-        XCTAssertEqual(event?.id, "event-id-1")
-        XCTAssertEqual(event?.data, "event-data-first")
-        XCTAssertEqual(event?.event, "testing event name")
-    }
+		let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
+		XCTAssertEqual(event?.id, "event-id-1")
+		XCTAssertEqual(event?.data, "event-data-first")
+		XCTAssertEqual(event?.event, "testing event name")
+	}
 
-    func testFullBasicEventWithSpaces() {
-        let eventsString = """
-        id:              event-id-1
-        data:            event-data-first
-        event:           testing event name
-        """
+	func testFullBasicEventWithSpaces() {
+		let eventsString = """
+		id:              event-id-1
+		data:            event-data-first
+		event:           testing event name
+		"""
 
-        let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
-        XCTAssertEqual(event?.id, "event-id-1")
-        XCTAssertEqual(event?.data, "event-data-first")
-        XCTAssertEqual(event?.event, "testing event name")
-    }
+		let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
+		XCTAssertEqual(event?.id, "event-id-1")
+		XCTAssertEqual(event?.data, "event-data-first")
+		XCTAssertEqual(event?.event, "testing event name")
+	}
 
-    func testEventWithMultipleLinesOfData() {
-        let eventsString = """
-        id: event-id-1
-        data: first line
-        data: second line
-        data: third line
-        event: testing event name
-        """
+	func testEventWithMultipleLinesOfData() {
+		let eventsString = """
+		id: event-id-1
+		data: first line
+		data: second line
+		data: third line
+		event: testing event name
+		"""
 
-        let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
-        XCTAssertEqual(event?.id, "event-id-1")
-        XCTAssertEqual(event?.data, "first line\nsecond line\nthird line")
-        XCTAssertEqual(event?.event, "testing event name")
-    }
+		let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
+		XCTAssertEqual(event?.id, "event-id-1")
+		XCTAssertEqual(event?.data, "first line\nsecond line\nthird line")
+		XCTAssertEqual(event?.event, "testing event name")
+	}
 
-    func testEventWithNoId() {
-        let eventsString = """
-        event: test-event
-        data: first line
-        """
+	func testEventWithNoId() {
+		let eventsString = """
+		event: test-event
+		data: first line
+		"""
 
-        let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
-        XCTAssertEqual(event?.id, nil)
-        XCTAssertEqual(event?.data, "first line")
-        XCTAssertEqual(event?.event, "test-event")
-    }
+		let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
+		XCTAssertEqual(event?.id, nil)
+		XCTAssertEqual(event?.data, "first line")
+		XCTAssertEqual(event?.event, "test-event")
+	}
 
-    func testEventWithEmptyId() {
-        let eventsString = """
-        id
-        data: first line
-        """
+	func testEventWithEmptyId() {
+		let eventsString = """
+		id
+		data: first line
+		"""
 
-        let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
-        XCTAssertEqual(event?.id, "")
-        XCTAssertEqual(event?.data, "first line")
-    }
+		let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
+		XCTAssertEqual(event?.id, "")
+		XCTAssertEqual(event?.data, "first line")
+	}
 
-    func testEventWithEmptyData() {
-        let eventsString = "data"
-        let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
-        XCTAssertEqual(event?.data, "")
-    }
+	func testEventWithEmptyData() {
+		let eventsString = "data"
+		let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
+		XCTAssertEqual(event?.data, "")
+	}
 
-    func testEventDobleEmptyData() {
-        let eventsString = """
-        data
-        data
-        """
+	func testEventDobleEmptyData() {
+		let eventsString = """
+		data
+		data
+		"""
 
-        let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
-        XCTAssertEqual(event?.data, "\n")
-    }
+		let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
+		XCTAssertEqual(event?.data, "\n")
+	}
 
-    func testEventWithRetryTime() {
-        let eventsString = """
-        id
-        data
-        data
-        retry: 1000
-        """
+	func testEventWithRetryTime() {
+		let eventsString = """
+		id
+		data
+		data
+		retry: 1000
+		"""
 
-        let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
-        XCTAssertEqual(event?.id, "")
-        XCTAssertEqual(event?.data, "\n")
-        XCTAssertEqual(event?.retryTime, 1000)
-    }
+		let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
+		XCTAssertEqual(event?.id, "")
+		XCTAssertEqual(event?.data, "\n")
+		XCTAssertEqual(event?.retryTime, 1000)
+	}
 
-    func testOnlyRetryTime() {
-        let eventsString = """
-        retry: 1000
-        """
+	func testOnlyRetryTime() {
+		let eventsString = """
+		retry: 1000
+		"""
 
-        let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
-        XCTAssertEqual(event?.onlyRetryEvent, true)
-    }
+		let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
+		XCTAssertEqual(event?.onlyRetryEvent, true)
+	}
 
-    func testOnlyRetryTimeWithEventInfo() {
-        let eventsString = """
-        retry: 1000
-        id
-        """
+	func testOnlyRetryTimeWithEventInfo() {
+		let eventsString = """
+		retry: 1000
+		id
+		"""
 
-        let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
-        XCTAssertEqual(event?.onlyRetryEvent, false)
-    }
+		let event = Event(eventString: eventsString, newLineCharacters: newLineCharacters)
+		XCTAssertEqual(event?.onlyRetryEvent, false)
+	}
 }


### PR DESCRIPTION
Allowing connection via various http methods. There's a lot of changes because I had to format the code.
The bulk of the changes are in the `EventSource.swift` file where I:
- Moved `url` and `headers` from the `init` to the `connect` method;
- Updated the `connect` method receive extra parameters `httpBody` and starting the connection via a `URLRequest` instead of only a `URL`;